### PR TITLE
Update to the Production config in Theme

### DIFF
--- a/config/production/hugo.yaml
+++ b/config/production/hugo.yaml
@@ -1,4 +1,4 @@
 # see https://hugomods.com/en/docs/google-analytics/.
-# googleAnalytics = 'G-XXXXXXXXXX' # Google Analytics, please make sure you've imported the Google Analytics module.
+# googleAnalytics: 'G-XXXXXXXXXX' # Google Analytics, please make sure you've imported the Google Analytics module.
 
 # disqusShortname: XXXXXX # The Disqus shortname.


### PR DESCRIPTION
Although commented out the googleAnalystics had a = instead of a colon this broke YAML formating when uncomment blindly.